### PR TITLE
Add placeholder GBS to VCF conversion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # gbs2vcf
 End-to-end GBS variant-calling for plants: QC → trimming → alignment → joint genotyping → filtered VCFs. 
+
+## Usage
+
+The repository includes a placeholder script, `convert_gbs_to_vcf.sh`, which demonstrates the
+expected interface for a future implementation. It copies the input file to the output
+location and prints status messages.
+
+Run it as:
+
+```bash
+./convert_gbs_to_vcf.sh input.vcf output.vcf
+```
+

--- a/convert_gbs_to_vcf.sh
+++ b/convert_gbs_to_vcf.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Simple placeholder script to convert a GBS dataset to VCF format.
+# Usage: ./convert_gbs_to_vcf.sh INPUT_FILE OUTPUT_FILE
+set -euo pipefail
+
+usage() {
+    cat <<USAGE
+Usage: $(basename "$0") INPUT_FILE OUTPUT_FILE
+Convert a GBS dataset to VCF format (placeholder).
+USAGE
+}
+
+if [[ $# -ne 2 ]]; then
+    usage
+    exit 1
+fi
+
+input="$1"
+output="$2"
+
+echo "Converting $input to $output"
+# Placeholder for actual conversion commands. For now just copy.
+cp "$input" "$output"
+echo "Done."


### PR DESCRIPTION
## Summary
- add placeholder `convert_gbs_to_vcf.sh` script demonstrating expected interface
- document usage in README

## Testing
- `./convert_gbs_to_vcf.sh >/tmp/log 2>&1 || cat /tmp/log`
- `echo "dummy" > input.vcf`
- `./convert_gbs_to_vcf.sh input.vcf output.vcf`
- `cat output.vcf`


------
https://chatgpt.com/codex/tasks/task_b_689d53b2552c832691f4e2adf1d39958