### PR TITLE
docs: add sample and barcode examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,22 @@ The repository provides `convert_gbs_2_vcf.sh`, a bash pipeline that runs qualit
 ./convert_gbs_2_vcf.sh
 ```
 
+Example `samples.txt`:
+
+```text
+sample1
+sample2
+sample3
+```
+
+Example `barcodes.txt` (tab-separated barcode definitions):
+
+```text
+ACTGTA	sample1
+CTTGAA	sample2
+GACTAG	sample3
+```
+
+During demultiplexing, the pipeline calls `process_radtags`, which reads `barcodes.txt` to split raw reads by barcode into per-sample FASTQs named for the sample identifiers. Those identifiers must also appear in `samples.txt`, which the script uses to iterate through subsequent steps.
+
 The final filtered VCF is written to `vcf/filtered_variants.vcf.gz`.


### PR DESCRIPTION
## Summary
- add example `samples.txt` and `barcodes.txt` snippets to README
- explain their role in demultiplexing

## Testing
- `bash -n convert_gbs_2_vcf.sh`


------
https://chatgpt.com/codex/tasks/task_b_689d79e70cf883268f2b6ec80ccea553