### PR TITLE
Document sample and barcode configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,22 @@ The repository provides `convert_gbs_2_vcf.sh`, a bash pipeline that runs qualit
 ./convert_gbs_2_vcf.sh
 ```
 
+Example `samples.txt`:
+
+```text
+sample1
+sample2
+sample3
+```
+
+Example `barcodes.txt` (tab-separated barcode definitions):
+
+```text
+ACTGTA	sample1
+CTTGAA	sample2
+GACTAG	sample3
+```
+
+During demultiplexing, the pipeline calls `process_radtags`, which reads `barcodes.txt` to split raw reads by barcode into per-sample FASTQs named for the sample identifiers. Those identifiers must also appear in `samples.txt`, which the script uses to iterate through subsequent steps.
+
 The final filtered VCF is written to `vcf/filtered_variants.vcf.gz`.

--- a/docs/sample_and_barcode_configuration.md
+++ b/docs/sample_and_barcode_configuration.md
@@ -1,0 +1,19 @@
+# Sample and Barcode Configuration for gbs2vcf
+
+The `gbs2vcf` pipeline uses two configuration files to map raw reads to specific samples before downstream analyses:
+
+1. **samples.txt** – a plain-text list of sample identifiers, one per line, used throughout the pipeline to track each specimen in subsequent processing stages.
+   ```text
+   sample1
+   sample2
+   sample3
+   ```
+
+2. **barcodes.txt** – a tab-separated table associating barcode sequences with the matching sample identifiers. During demultiplexing, the `process_radtags` step reads this file to split raw reads into per-sample FASTQ files named by the sample identifier.
+   ```text
+   ACTGTA	sample1
+   CTTGAA	sample2
+   GACTAG	sample3
+   ```
+
+It is crucial that each sample listed in `samples.txt` has a corresponding barcode entry in `barcodes.txt`, ensuring that `process_radtags` can correctly demultiplex the reads and the pipeline can iterate through each sample for trimming, alignment, and variant calling stages.


### PR DESCRIPTION
## Summary
- add wiki-style explanation of sample and barcode configuration files
- show how barcodes and sample names connect during demultiplexing

## Testing
- `bash -n convert_gbs_2_vcf.sh`


------
https://chatgpt.com/codex/tasks/task_b_689d79e70cf883268f2b6ec80ccea553